### PR TITLE
UI overhaul: Move activity cards to bottom, add register button, improve responsive design

### DIFF
--- a/src/static/app.js
+++ b/src/static/app.js
@@ -13,6 +13,7 @@ document.addEventListener("DOMContentLoaded", () => {
       // Clear loading message
       activitiesList.innerHTML = "";
 
+
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
@@ -45,15 +46,15 @@ document.addEventListener("DOMContentLoaded", () => {
           <div class="participants-container">
             ${participantsHTML}
           </div>
+          <button class="register-btn" data-activity="${name}">Register Student</button>
         `;
 
         activitiesList.appendChild(activityCard);
+      });
 
-        // Add option to select dropdown
-        const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
-        activitySelect.appendChild(option);
+      // Add event listeners to register buttons
+      document.querySelectorAll(".register-btn").forEach((button) => {
+        button.addEventListener("click", handleRegisterClick);
       });
 
       // Add event listeners to delete buttons
@@ -65,6 +66,16 @@ document.addEventListener("DOMContentLoaded", () => {
         "<p>Failed to load activities. Please try again later.</p>";
       console.error("Error fetching activities:", error);
     }
+  }
+
+  // Handle register button click
+  function handleRegisterClick(event) {
+    const activity = event.target.getAttribute("data-activity");
+    // Show the signup form and set the selected activity
+    signupForm.classList.remove("hidden");
+    document.getElementById("activity").value = activity;
+    document.getElementById("email").value = "";
+    document.getElementById("email").focus();
   }
 
   // Handle unregister functionality
@@ -132,6 +143,7 @@ document.addEventListener("DOMContentLoaded", () => {
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
+        signupForm.classList.add("hidden");
         signupForm.reset();
 
         // Refresh activities list to show updated participants

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -12,32 +12,29 @@
       <h2>Extracurricular Activities</h2>
     </header>
 
+
     <main>
+      <section id="signup-container">
+        <h3>Register Student</h3>
+        <form id="signup-form" class="hidden">
+          <div class="form-group">
+            <label for="email">Student Email:</label>
+            <input type="email" id="email" required placeholder="your-email@mergington.edu" />
+          </div>
+          <div class="form-group">
+            <label for="activity">Selected Activity:</label>
+            <input type="text" id="activity" readonly />
+          </div>
+          <button type="submit">Sign Up</button>
+        </form>
+        <div id="message" class="hidden"></div>
+      </section>
       <section id="activities-container">
         <h3>Available Activities</h3>
         <div id="activities-list">
           <!-- Activities will be loaded here -->
           <p>Loading activities...</p>
         </div>
-      </section>
-
-      <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
-        <form id="signup-form">
-          <div class="form-group">
-            <label for="email">Student Email:</label>
-            <input type="email" id="email" required placeholder="your-email@mergington.edu" />
-          </div>
-          <div class="form-group">
-            <label for="activity">Select Activity:</label>
-            <select id="activity" required>
-              <option value="">-- Select an activity --</option>
-              <!-- Activity options will be loaded here -->
-            </select>
-          </div>
-          <button type="submit">Sign Up</button>
-        </form>
-        <div id="message" class="hidden"></div>
       </section>
     </main>
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -3,7 +3,6 @@
   margin: 0;
   padding: 0;
   font-family: Arial, sans-serif;
-}
 
 body {
   font-family: Arial, sans-serif;
@@ -28,16 +27,26 @@ header h1 {
   margin-bottom: 10px;
 }
 
+
 main {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 30px;
-  justify-content: center;
+  align-items: center;
 }
 
 @media (min-width: 768px) {
   main {
-    grid-template-columns: 2fr 1fr;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
+  }
+  #signup-container {
+    max-width: 350px;
+    margin-right: 30px;
+  }
+  #activities-container {
+    max-width: 700px;
   }
 }
 
@@ -47,7 +56,8 @@ section {
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
   width: 100%;
-  max-width: 500px;
+  max-width: 700px;
+  margin-bottom: 20px;
 }
 
 section h3 {
@@ -188,8 +198,45 @@ button:hover {
   border: 1px solid #bee5eb;
 }
 
+/* Hide signup form by default */
 .hidden {
-  display: none;
+  display: none !important;
+}
+.register-btn {
+  display: block;
+  width: 100%;
+  margin-top: 12px;
+  padding: 10px 0;
+  background-color: #43a047;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.register-btn:hover {
+  background-color: #388e3c;
+}
+@media (max-width: 600px) {
+  main {
+    flex-direction: column;
+    gap: 20px;
+    align-items: stretch;
+  }
+  section {
+    max-width: 100%;
+    padding: 12px;
+  }
+  .activity-card {
+    padding: 10px;
+  }
+  .register-btn {
+    font-size: 15px;
+    padding: 8px 0;
+  }
+}
 }
 
 footer {


### PR DESCRIPTION
This PR addresses issue #7 (Prettier Interface):
- Moves activity cards to the bottom of the page
- Removes the registration form from the sidebar and adds a 'Register Student' button to each activity card
- Improves responsive design for desktop, phone, and tablet

Please review the changes and confirm if they look correct.